### PR TITLE
Convert EmpireSaveData from NPC to generic Saveable

### DIFF
--- a/Empire-S1API/GeneralSetup/Empire SaveData.cs
+++ b/Empire-S1API/GeneralSetup/Empire SaveData.cs
@@ -1,53 +1,34 @@
 using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using Empire;
 using MelonLoader;
-using MelonLoader.Utils;
-using S1API.Entities;
-using S1API.Internal.Utils;
-using S1API.PhoneApp;
+using S1API.Internal.Abstraction;
 using S1API.Saveables;
-using UnityEngine;
 using S1API.GameTime;
-using S1API.Logging;
 
 namespace Empire
 {
-    public class EmpireSaveData : NPC
+    public class EmpireSaveData : Saveable
     {
-
-
         [SaveableField("empire_save_data")]
-        public GlobalSaveData SaveData;
+        public GlobalSaveData SaveData = new GlobalSaveData();
 
-        public EmpireSaveData() : base("EmpireSaveData", "Empire", "SaveData")
+        public EmpireSaveData()
         {
             MelonLogger.Msg("Empire Save Data Constructor");
-            //if SaveData is null, create a new instance
-            if (SaveData == null)
-                SaveData = new GlobalSaveData();
-            //if GeneralSetup.EmpireSaveData is null, set it to this instance
             GeneralSetup.EmpireSaveData = this;
-
-
         }
 
         protected override void OnLoaded()
         {
-            base.OnLoaded();
             MelonLogger.Msg("Empire Save Data Loaded");
-            //GeneralSetup.EmpireSaveData = this;
+            GeneralSetup.EmpireSaveData = this;
         }
 
         protected override void OnCreated()
         {
-            base.OnCreated();
             MelonLogger.Msg("Empire Save Data Created");
-            //GeneralSetup.EmpireSaveData = this;
-            GeneralSetup.UncCalls();//ToDO - shift to proper flow
-            TimeManager.OnDayPass += GeneralSetup.ResetPlayerStats;//ToDO - shift to proper flow
+            GeneralSetup.EmpireSaveData = this;
+            GeneralSetup.UncCalls(); // TODO - shift to proper flow
+            TimeManager.OnDayPass += GeneralSetup.ResetPlayerStats; // TODO - shift to proper flow
         }
 
 

--- a/Empire-S1API/Mod.cs
+++ b/Empire-S1API/Mod.cs
@@ -1,5 +1,6 @@
 ﻿using MelonLoader;
 using Empire;
+using S1API.Saveables;
 
 [assembly: MelonInfo(typeof(MyMod), "Empire", "0.75", "Aracor")]
 [assembly: MelonGame("TVGS", "Schedule I")]
@@ -8,6 +9,11 @@ namespace Empire
 {
     public class MyMod : MelonMod
     {
-       
+        public override void OnInitializeMelon()
+        {
+            // Register the EmpireSaveData with the ModSaveableRegistry
+            var empireSaveData = new EmpireSaveData();
+            ModSaveableRegistry.Register(empireSaveData, "Empire");
+        }
     }
 }


### PR DESCRIPTION
Converts `EmpireSaveData` to inherit the generic `Saveable` class, then registers it in `Mod` class using S1API's `ModSaveableRegistry`